### PR TITLE
u

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ The script pulls down the latest version of cloudflared and installs it
 This Script cleanly uninstalls / removes cloudflared.
 
 
-## Todo
+## UPD
 
-* [ ] Openwrt LuCI App
+The OpenWrt packages feed now has the `cloudflared` package and Luci Application `luci-app-cloudflared` that provides a GUI for configuration.
+You can install them with the command `opkg install cloudflared luci-app-cloudflared`
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Supports Raspberry Pi 4 and x86 based OpenWrt Routers setting up Cloudflare tunnels
 
+
+> [!IMPORTANT]
+> The official OpenWrt packages feed now has the `cloudflared` package and Luci Application `luci-app-cloudflared` that provides a GUI for configuration.
+>  You can install them with the command `opkg install cloudflared luci-app-cloudflared`
+
+
+
 This install script will install a Cloudflare tunnel on an Raspberry Pi4 running as a OpenWrt Router\
 or running a machine based on OpenWrt x86\
 This allows both Locally or Web Managed Tunnels\
@@ -30,11 +37,4 @@ The script pulls down the latest version of cloudflared and installs it
 
 ## uninstall-cloudflared.sh
 This Script cleanly uninstalls / removes cloudflared.
-
-
-## UPD
-
-The OpenWrt packages feed now has the `cloudflared` package and Luci Application `luci-app-cloudflared` that provides a GUI for configuration.
-You can install them with the command `opkg install cloudflared luci-app-cloudflared`
-
 


### PR DESCRIPTION
> [!IMPORTANT]
> The official OpenWrt packages feed now has the `cloudflared` package and Luci Application `luci-app-cloudflared` that provides a GUI for configuration.
>  You can install them with the command `opkg install cloudflared luci-app-cloudflared`

It's available starting from version 23.03 https://github.com/openwrt/packages/tree/master/net/cloudflared

Please test it and contribute.

Currently there is a problem that on the latest snapshot version it can't be compiled but that problem will be solved soon.


check the doc https://openwrt.org/docs/guide-user/services/vpn/cloudfare_tunnel

Also please archive the repository.
